### PR TITLE
core: Add SimpleJsonOutputParser type to _load_output_parser()

### DIFF
--- a/libs/core/langchain_core/prompts/loading.py
+++ b/libs/core/langchain_core/prompts/loading.py
@@ -7,6 +7,7 @@ from typing import Callable, Dict, Union
 import yaml
 
 from langchain_core.output_parsers.string import StrOutputParser
+from langchain_core.output_parsers.json import SimpleJsonOutputParser
 from langchain_core.prompts.base import BasePromptTemplate
 from langchain_core.prompts.chat import ChatPromptTemplate
 from langchain_core.prompts.few_shot import FewShotPromptTemplate
@@ -79,6 +80,8 @@ def _load_output_parser(config: dict) -> dict:
         output_parser_type = _config.pop("_type")
         if output_parser_type == "default":
             output_parser = StrOutputParser(**_config)
+        elif output_parser_type == "simple_json_output_parser":
+            output_parser = SimpleJsonOutputParser(**_config)
         else:
             raise ValueError(f"Unsupported output parser {output_parser_type}")
         config["output_parser"] = output_parser


### PR DESCRIPTION
In this PR, we are adding support for simple_json_output_parser type In the `_load_output_parser()` function.

<--
If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->
